### PR TITLE
PHP 5.4 compatibility

### DIFF
--- a/jsonreader.c
+++ b/jsonreader.c
@@ -203,7 +203,12 @@ zval* jsonreader_read_property(zval *object, zval *member, int type TSRMLS_DC)
 		}
 	} else {
 		std_hnd = zend_get_std_object_handlers();
+#if PHP_VERSION_ID < 50399
 		retval = std_hnd->read_property(object, member, type TSRMLS_CC);
+#else
+		retval = std_hnd->read_property(object, member, type TSRMLS_CC, NULL);
+#endif
+
 	}
 
 	if (member == &tmp_member) { 
@@ -240,7 +245,11 @@ void jsonreader_write_property(zval *object, zval *member, zval *value TSRMLS_DC
 		jph->write_func(intern, value TSRMLS_CC);
 	} else {
 		std_hnd = zend_get_std_object_handlers();
+#if PHP_VERSION_ID < 50399
 		std_hnd->write_property(object, member, value TSRMLS_CC);
+#else
+		std_hnd->write_property(object, member, value TSRMLS_CC, NULL);
+#endif
 	}
 
 	if (member == &tmp_member) { 
@@ -428,8 +437,13 @@ static zend_object_value jsonreader_object_new(zend_class_entry *ce TSRMLS_DC)
 	intern->errmode = ERRMODE_PHPERR;
 
 	zend_object_std_init(&(intern->std), ce TSRMLS_CC);
+  
+#if PHP_VERSION_ID < 50399
 	zend_hash_copy(intern->std.properties, &ce->default_properties, 
 		(copy_ctor_func_t) zval_add_ref, NULL, sizeof(zval *));
+#else
+  object_properties_init(&(intern->std), ce);
+#endif
 
 	retval.handle = zend_objects_store_put(intern, 
 		(zend_objects_store_dtor_t) zend_objects_destroy_object, 


### PR DESCRIPTION
Changes for PHP 5.4 compatibility

Tested on

> PHP 5.4.15-1ubuntu3 (cli) (built: Jun 28 2013 17:41:13) 
> Copyright (c) 1997-2013 The PHP Group
> Zend Engine v2.4.0, Copyright (c) 1998-2013 Zend Technologies
>     with Xdebug v2.2.3, Copyright (c) 2002-2013, by Derick Rethans

and

> PHP 5.3.10-1ubuntu3.6 with Suhosin-Patch (cli) (built: Mar 11 2013 14:31:48) 
> Copyright (c) 1997-2012 The PHP Group
> Zend Engine v2.3.0, Copyright (c) 1998-2012 Zend Technologies

One test fails on both versions before this patch is applied and after.

``` =====================================================================
TIME START 2013-07-03 15:20:40
=====================================================================
PASS Check for jsonreader presence [tests/001.phpt] 
PASS Parse a simple short array [tests/002.phpt] 
PASS Parse a simple JSON object into an associative array [tests/003.phpt] 
PASS Parse some integers and floating-point numbers [tests/004.phpt] 
PASS parse a multi-dimentional JSON array and use the currentDepth property [tests/005.phpt] 
PASS Test that an error occurs when passing the maximal nesting level [tests/006.phpt] 
PASS Test that we can modify the max nesting level through an INI setting [tests/007.phpt] 
PASS Test that we can modify the max nesting level through a constructor attribute [tests/008.phpt] 
PASS Test that the constructor takes the right argument(s) [tests/009.phpt] 
PASS Check that the JSONReaderException class is available [tests/010.phpt] 
PASS Test that a warning is thrown in case of a JSON parse error [tests/011.phpt] 
PASS Test that an exception is thrown when ERRMODE_EXCEPT is set [tests/012.phpt] 
PASS Test that the value property is null for non-value tokens [tests/013.phpt] 
FAIL Test that we can get the current struct using currentStruct [tests/014.phpt] 
=====================================================================
TIME END 2013-07-03 15:20:41
```
