### PR TITLE
PHP 5.5 compatibility

### DIFF
--- a/jsonreader.c
+++ b/jsonreader.c
@@ -36,7 +36,7 @@ static zend_object_handlers  jsonreader_obj_handlers;
 static zend_class_entry     *jsonreader_ce;
 static zend_class_entry     *jsonreader_exception_ce;
 
-HashTable *jsonreader_prop_handlers;
+const HashTable *jsonreader_prop_handlers;
 
 typedef struct _jsonreader_object { 
 	zend_object   std;
@@ -165,14 +165,18 @@ static void jsonreader_register_prop_handler(char *name, jsonreader_read_t read_
 	jph.read_func  = read_func ? read_func : jsonreader_read_na;
 	jph.write_func = write_func ? write_func : jsonreader_write_na;
 
-	zend_hash_add(jsonreader_prop_handlers, name, strlen(name) + 1, &jph, 
+	zend_hash_add((HashTable *)jsonreader_prop_handlers, name, strlen(name) + 1, &jph,
 		sizeof(jsonreader_prop_handler), NULL);
 }
 /* }}} */
 
 /* {{{ jsonreader_read_property
    Property read handler */
+#if PHP_VERSION_ID < 50399
 zval* jsonreader_read_property(zval *object, zval *member, int type TSRMLS_DC)
+#else
+zval* jsonreader_read_property(zval *object, zval *member, int type TSRMLS_DC, const struct _zend_literal *zl)
+#endif
 {
 	jsonreader_object       *intern;
 	zval                     tmp_member;
@@ -191,7 +195,7 @@ zval* jsonreader_read_property(zval *object, zval *member, int type TSRMLS_DC)
 	ret = FAILURE;
 	intern = (jsonreader_object *) zend_objects_get_address(object TSRMLS_CC);
 
-	ret = zend_hash_find(jsonreader_prop_handlers, Z_STRVAL_P(member), 
+	ret = zend_hash_find((HashTable *)jsonreader_prop_handlers, Z_STRVAL_P(member),
 		Z_STRLEN_P(member) + 1, (void **) &jph);
 
 	if (ret == SUCCESS) {
@@ -220,7 +224,11 @@ zval* jsonreader_read_property(zval *object, zval *member, int type TSRMLS_DC)
 /* }}} */
 
 /* {{{ jsonreader_write_property */
+#if PHP_VERSION_ID < 50399
 void jsonreader_write_property(zval *object, zval *member, zval *value TSRMLS_DC)
+#else
+void jsonreader_write_property(zval *object, zval *member, zval *value TSRMLS_DC, const struct _zend_literal *zl)
+#endif
 {
 	jsonreader_object       *intern;
 	zval                     tmp_member;
@@ -238,7 +246,7 @@ void jsonreader_write_property(zval *object, zval *member, zval *value TSRMLS_DC
 	ret = FAILURE;
 	intern = (jsonreader_object *) zend_objects_get_address(object TSRMLS_CC);
 
-	ret = zend_hash_find(jsonreader_prop_handlers, Z_STRVAL_P(member), 
+	ret = zend_hash_find((HashTable *)jsonreader_prop_handlers, Z_STRVAL_P(member),
 		Z_STRLEN_P(member) + 1, (void **) &jph);
 
 	if (ret == SUCCESS) {
@@ -767,14 +775,14 @@ PHP_MINIT_FUNCTION(jsonreader)
 	zend_class_entry ce;
 
 	REGISTER_INI_ENTRIES();
-
+    
 	/**
 	 * Declare the JSONReader class 
 	 */
 
 	/* Set object handlers */
 	ALLOC_HASHTABLE(jsonreader_prop_handlers);
-	zend_hash_init(jsonreader_prop_handlers, 0, NULL, NULL, 1);
+	zend_hash_init((HashTable *)jsonreader_prop_handlers, 0, NULL, NULL, 0);
 	memcpy(&jsonreader_obj_handlers, zend_get_std_object_handlers(), 
 		sizeof(zend_object_handlers));
 	jsonreader_obj_handlers.read_property = jsonreader_read_property;
@@ -838,8 +846,11 @@ PHP_MINIT_FUNCTION(jsonreader)
 PHP_MSHUTDOWN_FUNCTION(jsonreader)
 {
 	UNREGISTER_INI_ENTRIES();
-	zend_hash_destroy(jsonreader_prop_handlers);
-	return SUCCESS;
+    
+//    zend_hash_destroy((HashTable *)jsonreader_prop_handlers);
+//    FREE_HASHTABLE((void *)jsonreader_prop_handlers);
+    
+    return SUCCESS;
 }
 /* }}} */
 


### PR DESCRIPTION
After upgrading to PHP 5.5 I got a 'Bus Error 10' when including the module.

```
gdb php
(gdb) set args -m
(gdb) run

...

Program received signal EXC_BAD_ACCESS, Could not access memory.
Reason: KERN_PROTECTION_FAILURE at address: 0x0000000100aed4e0
0x00000001001d1409 in _zend_hash_init ()
(gdb) bt
#0  0x00000001001d1409 in _zend_hash_init ()
#1  0x0000000100aea608 in zm_startup_jsonreader (type=<value temporarily unavailable, due to optimizations>, module_number=<value temporarily unavailable, due to optimizations>) at jsonreader.c:776
#2  0x00000001001cb78d in zend_startup_module_ex ()
#3  0x00000001001d273d in zend_hash_apply ()
#4  0x00000001001cbb33 in zend_startup_modules ()
#5  0x0000000100172e47 in php_module_startup ()
#6  0x000000010024df6f in php_cli_startup ()
#7  0x000000010024c4fe in main ()
```

Allocating the _jsonreader_prop_handlers_ HashTable solved this problem.
